### PR TITLE
Update group-related models

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -169,6 +169,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
+    public ObservableList<Group> getGroupList() {
+        return groups.asUnmodifiableObservableList();
+    }
+
+    @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof AddressBook // instanceof handles nulls

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -16,6 +16,9 @@ public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 
+    /** {@code Predicate} that always evaluate to true */
+    Predicate<Group> PREDICATE_SHOW_ALL_GROUPS = unused -> true;
+
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
      */
@@ -81,6 +84,9 @@ public interface Model {
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 
+    /** Returns an unmodifiable view of the filtered person list */
+    ObservableList<Group> getFilteredGroupList();
+
     /**
      * Adds the given person into a group.
      * {@code person} must not already exist in the {@code group}
@@ -109,7 +115,10 @@ public interface Model {
      * Returns true if a group with the same group name as {@code group} exists in the address book.
      */
     boolean hasGroup(Group group);
+
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    void updateFilteredGroupList(Predicate<Group> predicate);
 
     /**
      * Add IsolatedEvent object to the person's isolated event list.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -24,6 +24,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final FilteredList<Group> filteredGroups;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -36,6 +37,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        filteredGroups = new FilteredList<>(this.addressBook.getGroupList());
     }
 
     public ModelManager() {
@@ -161,6 +163,24 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+
+
+    //=========== Filtered Group List Accessors =============================================================
+    /**
+     * Returns an unmodifiable view of the list of {@code Group} backed by the internal list of
+     * {@code versionedAddressBook}
+     */
+    @Override
+    public ObservableList<Group> getFilteredGroupList() {
+        return filteredGroups;
+    }
+
+    @Override
+    public void updateFilteredGroupList(Predicate<Group> predicate) {
+        requireNonNull(predicate);
+        filteredGroups.setPredicate(predicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 
 /**
@@ -13,5 +14,11 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate persons.
      */
     ObservableList<Person> getPersonList();
+
+    /**
+     * Returns an unmodifiable view of the groups list.
+     * This list will not contain any duplicate groups.
+     */
+    ObservableList<Group> getGroupList();
 
 }

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -1,8 +1,5 @@
 package seedu.address.model.group;
 
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -1,5 +1,8 @@
 package seedu.address.model.group;
 
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
@@ -25,6 +28,10 @@ public class Group {
         this.groupName = groupName;
     }
 
+    public String getName() {
+        return groupName;
+    }
+
     /**
      * Returns true if a given string is a valid tag name.
      */
@@ -33,7 +40,20 @@ public class Group {
     }
 
     /**
-     * Returns true if both grouos are the same group object or have the same group name
+     * Returns true if both persons have the same name.
+     * This defines a weaker notion of equality between two persons.
+     */
+    public boolean isSameGroup(Group otherGroup) {
+        if (otherGroup == this) {
+            return true;
+        }
+
+        return otherGroup != null
+                && otherGroup.getName().equals(getName());
+    }
+
+    /**
+     * Returns true if both groups are the same group object or have the same group name
      */
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -30,15 +30,15 @@ public class Group {
     }
 
     /**
-     * Returns true if a given string is a valid tag name.
+     * Returns true if a given string is a valid group name.
      */
     public static boolean isValidGroupName(String test) {
         return test.matches(VALIDATION_REGEX);
     }
 
     /**
-     * Returns true if both persons have the same name.
-     * This defines a weaker notion of equality between two persons.
+     * Returns true if both groups have the same name.
+     * This defines a weaker notion of equality between two groups.
      */
     public boolean isSameGroup(Group otherGroup) {
         if (otherGroup == this) {

--- a/src/main/java/seedu/address/model/group/UniqueGroupList.java
+++ b/src/main/java/seedu/address/model/group/UniqueGroupList.java
@@ -2,7 +2,6 @@ package seedu.address.model.group;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -12,7 +11,6 @@ import javafx.collections.ObservableList;
 import seedu.address.model.group.exceptions.DuplicateGroupException;
 import seedu.address.model.group.exceptions.GroupNotFoundException;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.UniquePersonList;
 
 /**
  * A list of persons that enforces uniqueness between its elements and does not allow nulls.
@@ -61,6 +59,9 @@ public class UniqueGroupList implements Iterable<Group> {
         internalList.remove(toRemove);
     }
 
+    /**
+     * Returns true if the list contains an equivalent group as the given argument.
+     */
     public boolean contains(Group toCheck) {
         requireNonNull(toCheck);
         return internalList.stream().anyMatch(toCheck::isSameGroup);

--- a/src/main/java/seedu/address/model/group/UniqueGroupList.java
+++ b/src/main/java/seedu/address/model/group/UniqueGroupList.java
@@ -1,6 +1,7 @@
 package seedu.address.model.group;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
@@ -11,6 +12,7 @@ import javafx.collections.ObservableList;
 import seedu.address.model.group.exceptions.DuplicateGroupException;
 import seedu.address.model.group.exceptions.GroupNotFoundException;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
 
 /**
  * A list of persons that enforces uniqueness between its elements and does not allow nulls.
@@ -79,15 +81,23 @@ public class UniqueGroupList implements Iterable<Group> {
         return internalList.iterator();
     }
 
-    /**
-     * Replaces the contents of this list with {@code groups}.
-     * {@code groups} must not contain duplicate groups.
-     */
     public void setGroups(UniqueGroupList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);
     }
 
+    /**
+     * Replaces the contents of this list with {@code groups}.
+     * {@code groups} must not contain duplicate persons.
+     */
+    public void setGroups(List<Group> groups) {
+        requireAllNonNull(groups);
+        if (!groupsAreUnique(groups)) {
+            throw new DuplicateGroupException();
+        }
+
+        internalList.setAll(groups);
+    }
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/model/group/UniqueGroupList.java
+++ b/src/main/java/seedu/address/model/group/UniqueGroupList.java
@@ -3,19 +3,33 @@ package seedu.address.model.group;
 import static java.util.Objects.requireNonNull;
 
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import seedu.address.model.group.exceptions.DuplicateGroupException;
 import seedu.address.model.group.exceptions.GroupNotFoundException;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.UniquePersonList;
 
 /**
- * A list of groups that enforces uniqueness between its elements and does not allow nulls.
- * A group is considered unique by comparing using group name and object
+ * A list of persons that enforces uniqueness between its elements and does not allow nulls.
+ * A group is considered unique by comparing using {@code Group#isSameGroup(Group)}. As such, adding and updating of
+ * groups uses Group#isSameGroup(Group) for equality so as to ensure that the group being added or updated is
+ * unique in terms of identity in the UniqueGroupList. However, the removal of a group uses Group#equals(Object) so
+ * as to ensure that the person with exactly the same fields will be removed.
+ *
+ * Supports a minimal set of list operations.
+ *
+ * @see Group#isSameGroup(Group)
  */
-public class UniqueGroupList {
+public class UniqueGroupList implements Iterable<Group> {
 
-    private Set<Group> groups = new HashSet<>();
+    private final ObservableList<Group> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Group> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
 
     /**
      * Adds a group to the set.
@@ -25,10 +39,10 @@ public class UniqueGroupList {
      */
     public void add(Group toAdd) {
         requireNonNull(toAdd);
-        if (groups.contains(toAdd)) {
+        if (contains(toAdd)) {
             throw new DuplicateGroupException();
         }
-        groups.add(toAdd);
+        internalList.add(toAdd);
     }
 
     /**
@@ -40,20 +54,64 @@ public class UniqueGroupList {
      */
     public void delete(Group toRemove, Set<Person> persons) {
         requireNonNull(toRemove);
-        if (!groups.contains(toRemove)) {
+        if (!contains(toRemove)) {
             throw new GroupNotFoundException();
         }
         persons.forEach(person -> person.removeGroup(toRemove));
-        groups.remove(toRemove);
+        internalList.remove(toRemove);
     }
 
     public boolean contains(Group toCheck) {
-        return groups.contains(toCheck);
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSameGroup);
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Group> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<Group> iterator() {
+        return internalList.iterator();
+    }
+
+    /**
+     * Replaces the contents of this list with {@code groups}.
+     * {@code groups} must not contain duplicate groups.
+     */
+    public void setGroups(UniqueGroupList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UniqueGroupList // instanceof handles nulls
+                && internalList.equals(((UniqueGroupList) other).internalList));
     }
 
     @Override
     public int hashCode() {
-        return groups.hashCode();
+        return internalList.hashCode();
+    }
+
+    /**
+     * Returns true if {@code persons} contains only unique persons.
+     */
+    private boolean groupsAreUnique(List<Group> groups) {
+        for (int i = 0; i < groups.size() - 1; i++) {
+            for (int j = i + 1; j < groups.size(); j++) {
+                if (groups.get(i).isSameGroup(groups.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }
 

--- a/src/main/java/seedu/address/model/group/UniqueGroupList.java
+++ b/src/main/java/seedu/address/model/group/UniqueGroupList.java
@@ -12,7 +12,6 @@ import javafx.collections.ObservableList;
 import seedu.address.model.group.exceptions.DuplicateGroupException;
 import seedu.address.model.group.exceptions.GroupNotFoundException;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.exceptions.DuplicatePersonException;
 
 /**
  * A list of persons that enforces uniqueness between its elements and does not allow nulls.

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -171,7 +171,17 @@ public class AddCommandTest {
         }
 
         @Override
+        public ObservableList<Group> getFilteredGroupList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredGroupList(Predicate<Group> predicate) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -122,6 +122,7 @@ public class AddressBookTest {
      */
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Person> persons = FXCollections.observableArrayList();
+        private final ObservableList<Group> groups = FXCollections.observableArrayList();
 
         AddressBookStub(Collection<Person> persons) {
             this.persons.setAll(persons);
@@ -130,6 +131,11 @@ public class AddressBookTest {
         @Override
         public ObservableList<Person> getPersonList() {
             return persons;
+        }
+
+        @Override
+        public ObservableList<Group> getGroupList() {
+            return groups;
         }
     }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -94,6 +94,11 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void getFilteredGroupList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredGroupList().remove(0));
+    }
+
+    @Test
     public void equals() {
         AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).build();
         AddressBook differentAddressBook = new AddressBook();

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
 
@@ -86,6 +87,19 @@ public class ModelManagerTest {
     public void hasPerson_personInAddressBook_returnsTrue() {
         modelManager.addPerson(ALICE);
         assertTrue(modelManager.hasPerson(ALICE));
+    }
+
+    @Test
+    public void hasGroup_groupNotInAddressBook_returnsFalse() {
+        Group group = new Group("2103");
+        assertFalse(modelManager.hasGroup(group));
+    }
+
+    @Test
+    public void hasGroup_groupInAddressBook_returnsTrue() {
+        Group group = new Group("2103");
+        modelManager.addGroup(group);
+        assertTrue(modelManager.hasGroup(group));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/group/GroupTest.java
+++ b/src/test/java/seedu/address/model/group/GroupTest.java
@@ -11,8 +11,9 @@ public class GroupTest {
     public void equals() {
         Group group1 = new Group("2103T");
         Group group2 = new Group("2101");
+        Group group1Duplicate = new Group("2103T");
         assertFalse(group1.equals(group2));
-        assertTrue(group1.equals(group1));
+        assertTrue(group1.equals(group1Duplicate));
 
     }
 
@@ -29,5 +30,5 @@ public class GroupTest {
         assertFalse(group1.toString().equals("[2101]"));
     }
 
-
+    // TODO: More tests
 }

--- a/src/test/java/seedu/address/model/group/GroupTest.java
+++ b/src/test/java/seedu/address/model/group/GroupTest.java
@@ -6,12 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 public class GroupTest {
+    Group group1 = new Group("2103T");
+    Group group2 = new Group("2101");
+    Group group1Duplicate = new Group("2103T");
 
     @Test
     public void equals() {
-        Group group1 = new Group("2103T");
-        Group group2 = new Group("2101");
-        Group group1Duplicate = new Group("2103T");
         assertFalse(group1.equals(group2));
         assertTrue(group1.equals(group1Duplicate));
 
@@ -24,11 +24,16 @@ public class GroupTest {
     }
 
     @Test
+    public void isSameGroup() {
+        assertTrue(group1.isSameGroup(group1));
+        assertTrue(group1.isSameGroup(group1Duplicate));
+        assertFalse(group1.isSameGroup(group2));
+    }
+
+    @Test
     public void output() {
         Group group1 = new Group("2103T");
         assertTrue(group1.toString().equals("[2103T]"));
         assertFalse(group1.toString().equals("[2101]"));
     }
-
-    // TODO: More tests
 }

--- a/src/test/java/seedu/address/model/group/GroupTest.java
+++ b/src/test/java/seedu/address/model/group/GroupTest.java
@@ -6,9 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 public class GroupTest {
-    Group group1 = new Group("2103T");
-    Group group2 = new Group("2101");
-    Group group1Duplicate = new Group("2103T");
+    private final Group group1 = new Group("2103T");
+    private final Group group2 = new Group("2101");
+    private final Group group1Duplicate = new Group("2103T");
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/model/group/UniqueGroupListTest.java
+++ b/src/test/java/seedu/address/model/group/UniqueGroupListTest.java
@@ -1,9 +1,9 @@
 package seedu.address.model.group;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.ALICE;
-import static seedu.address.testutil.TypicalPersons.BOB;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -15,13 +15,12 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.group.exceptions.DuplicateGroupException;
 import seedu.address.model.group.exceptions.GroupNotFoundException;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.UniquePersonList;
 
 public class UniqueGroupListTest {
     private final UniqueGroupList emptyGroupList = new UniqueGroupList();
-    Group group = new Group("2103T");
-    Group groupWithSameName = new Group("2103T");
-    Group anotherGroup = new Group("2101");
+    private final Group group = new Group("2103T");
+    private final Group groupWithSameName = new Group("2103T");
+    private final Group anotherGroup = new Group("2101");
 
     @Test
     public void addGroupToList() {

--- a/src/test/java/seedu/address/model/group/UniqueGroupListTest.java
+++ b/src/test/java/seedu/address/model/group/UniqueGroupListTest.java
@@ -43,4 +43,5 @@ public class UniqueGroupListTest {
         });
     }
 
+    // TODO: More tests
 }

--- a/src/test/java/seedu/address/model/group/UniqueGroupListTest.java
+++ b/src/test/java/seedu/address/model/group/UniqueGroupListTest.java
@@ -1,47 +1,90 @@
 package seedu.address.model.group;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.group.exceptions.DuplicateGroupException;
 import seedu.address.model.group.exceptions.GroupNotFoundException;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.UniquePersonList;
 
 public class UniqueGroupListTest {
+    private final UniqueGroupList emptyGroupList = new UniqueGroupList();
+    Group group = new Group("2103T");
+    Group groupWithSameName = new Group("2103T");
+    Group anotherGroup = new Group("2101");
 
     @Test
     public void addGroupToList() {
-        Group group1 = new Group("2103T");
         UniqueGroupList ugl = new UniqueGroupList();
-        ugl.add(group1);
-        assertTrue(ugl.contains(group1));
-        Assertions.assertThrows(NullPointerException.class, () -> {
-            ugl.add(null);
-        });
-        Assertions.assertThrows(DuplicateGroupException.class, () -> {
-            ugl.add(group1);
-        });
+        assertFalse(ugl.contains(group));
+        ugl.add(group);
+        assertTrue(ugl.contains(group));
+        assertTrue(ugl.contains(groupWithSameName));
+        assertThrows(NullPointerException.class, () -> ugl.add(null));
+        assertThrows(DuplicateGroupException.class, () -> ugl.add(group));
     }
 
     @Test
     public void removeGroupFromList() {
-        Group group1 = new Group("2103T");
         UniqueGroupList ugl = new UniqueGroupList();
-        ugl.add(group1);
-        ugl.delete(group1, new HashSet<Person>());
-        assertFalse(ugl.contains(group1));
-        Assertions.assertThrows(NullPointerException.class, () -> {
+        ugl.add(group);
+        ugl.delete(group, new HashSet<Person>());
+        assertFalse(ugl.contains(group));
+        assertThrows(NullPointerException.class, () -> {
             ugl.delete(null, new HashSet<Person>());
         });
-        Assertions.assertThrows(GroupNotFoundException.class, () -> {
-            ugl.delete(group1, new HashSet<Person>());
+        assertThrows(GroupNotFoundException.class, () -> {
+            ugl.delete(group, new HashSet<Person>());
         });
     }
 
-    // TODO: More tests
+    @Test
+    public void add_duplicateGroup_throwsDuplicateGroupException() {
+        UniqueGroupList ugl = new UniqueGroupList();
+        ugl.add(group);
+        assertThrows(DuplicateGroupException.class, () -> ugl.add(groupWithSameName));
+    }
+
+    @Test
+    public void setPersons_uniquePersonList_replacesOwnListWithProvidedUniquePersonList() {
+        UniqueGroupList startUniqueGroupList = new UniqueGroupList();
+        UniqueGroupList expectedUniqueGroupList = new UniqueGroupList();
+        expectedUniqueGroupList.add(group);
+        startUniqueGroupList.setGroups(expectedUniqueGroupList);
+        assertEquals(expectedUniqueGroupList, startUniqueGroupList);
+    }
+
+    @Test
+    public void setGroups_list_replacesOwnListWithProvidedList() {
+        UniqueGroupList startUniqueGroupList = new UniqueGroupList();
+        startUniqueGroupList.add(group);
+        List<Group> groupList = Collections.singletonList(anotherGroup);
+        startUniqueGroupList.setGroups(groupList);
+        UniqueGroupList expectedUniqueGroupList = new UniqueGroupList();
+        expectedUniqueGroupList.add(anotherGroup);
+        assertEquals(expectedUniqueGroupList, startUniqueGroupList);
+    }
+
+    @Test
+    public void setGroups_listWithDuplicateGroups_throwsDuplicateGroupException() {
+        List<Group> listWithDuplicateGroups = Arrays.asList(group, groupWithSameName);
+        assertThrows(DuplicateGroupException.class, () -> emptyGroupList.setGroups(listWithDuplicateGroups));
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        UniqueGroupList ugl = new UniqueGroupList();
+        assertThrows(UnsupportedOperationException.class, ()
+                -> ugl.asUnmodifiableObservableList().remove(0));
+    }
 }


### PR DESCRIPTION
Update Group-related classes to be similar to those of Person instead of using HashSet.

Reasons:
1. Commands will be working with indexes based on the displayed list but iterator over HashSet doesn't produce a fixed order.
2. Text display of Group information will not be sufficient in the future since we will incorporate other data such as Events and free time slots. Thus, UI will require an ObservableList for groups in the future. Because of this, a large portion of the methods as shown in UniquePersonList and Person are required in the Group classes as well.
