### PR TITLE
Fix bug for event list

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddIsolatedEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddIsolatedEventCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import seedu.address.commons.core.Messages;
@@ -12,9 +11,6 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.event.IsolatedEvent;
 import seedu.address.model.event.IsolatedEventList;
-import seedu.address.model.event.RecurringEvent;
-import seedu.address.model.event.RecurringEventList;
-import seedu.address.model.event.exceptions.EventConflictException;
 import seedu.address.model.person.Person;
 
 
@@ -51,6 +47,9 @@ public class AddIsolatedEventCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        eventToAdd.checkDateTime();
+
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
@@ -59,11 +58,6 @@ public class AddIsolatedEventCommand extends Command {
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
 
-        String checkConflictsInRecurringList = listConflictedEventWithRecurring(eventToAdd, personToEdit);
-
-        if (!checkConflictsInRecurringList.equals("0")) {
-            throw new EventConflictException(checkConflictsInRecurringList);
-        }
         IsolatedEventList isolatedEventList = personToEdit.getIsolatedEventList();
         IsolatedEvent checkForEventClash = isolatedEventList.checkClashingIsolatedEvent(eventToAdd.getStartDate(),
                 eventToAdd.getEndDate());
@@ -72,33 +66,12 @@ public class AddIsolatedEventCommand extends Command {
             throw new CommandException(String.format(Messages.MESSAGE_EVENT_CLASH, checkForEventClash));
         }
 
-        eventToAdd.checkDateTime();
+        IsolatedEventList.listConflictedEventWithRecurring(eventToAdd, personToEdit.getRecurringEventList());
 
         model.addIsolatedEvent(personToEdit, eventToAdd);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, eventToAdd) + " to "
                 + personToEdit.getName());
-    }
-
-    /**
-     * This function cross-check with the recurring event list to check for any conflicts
-     * @param isolatedEvent is the event to be added
-     * @param person of the event that is to be added
-     * @return "0" if there are no conflicts and return the conflicted event string if there is a conflict
-     */
-    public String listConflictedEventWithRecurring(IsolatedEvent isolatedEvent, Person person) {
-        LocalDateTime startPeriod = isolatedEvent.getStartDate();
-        LocalDateTime endPeriod = isolatedEvent.getEndDate();
-
-        RecurringEventList recurringEventList = person.getRecurringEventList();
-
-        int index = 1;
-        for (RecurringEvent re : recurringEventList.getRecurringEvents()) {
-            if (re.occursBetween(startPeriod, endPeriod)) {
-                return "Recurring Event List:\n" + index + " " + re;
-            }
-        }
-        return "0";
     }
 }

--- a/src/main/java/seedu/address/logic/commands/AddRecurringEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddRecurringEventCommand.java
@@ -9,11 +9,8 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.event.IsolatedEvent;
-import seedu.address.model.event.IsolatedEventList;
 import seedu.address.model.event.RecurringEvent;
 import seedu.address.model.event.RecurringEventList;
-import seedu.address.model.event.exceptions.EventConflictException;
 import seedu.address.model.person.Person;
 
 /**
@@ -69,13 +66,7 @@ public class AddRecurringEventCommand extends Command {
             throw new CommandException(String.format(Messages.MESSAGE_EVENT_CLASH, checkForEventClash));
         }
 
-        String checkConflictsInIsolatedList =
-                RecurringEventList.listConflictedEventWithIsolated(eventToAdd, personToEdit.getIsolatedEventList());
-
-
-        if (!checkConflictsInIsolatedList.equals("0")) {
-            throw new EventConflictException(checkConflictsInIsolatedList);
-        }
+        RecurringEventList.listConflictedEventWithIsolated(eventToAdd, personToEdit.getIsolatedEventList());
 
         model.addRecurringEvent(personToEdit, eventToAdd);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
@@ -83,23 +74,5 @@ public class AddRecurringEventCommand extends Command {
         return new CommandResult(String.format(MESSAGE_SUCCESS, eventToAdd) + " to "
                 + personToEdit.getName());
 
-    }
-
-    /**
-     * This function cross-check with the isolated event list to check for any conflicts
-     * @param recurringEvent is the event to be added
-     * @param person of the event that is to be added
-     * @return "0" if there are no conflicts and return the conflicted event string if there is a conflict
-     */
-    public String listConflictedEventWithIsolated(RecurringEvent recurringEvent, Person person) {
-
-        IsolatedEventList isolatedEventList = person.getIsolatedEventList();
-        int index = 1;
-        for (IsolatedEvent ie : isolatedEventList.getIsolatedEvents()) {
-            if (recurringEvent.occursBetween(ie.getStartDate(), ie.getEndDate())) {
-                return "Isolated Event List:\n" + index + " " + ie;
-            }
-        }
-        return "0";
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditIsolatedEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditIsolatedEventCommand.java
@@ -15,6 +15,7 @@ import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.event.IsolatedEvent;
+import seedu.address.model.event.IsolatedEventList;
 import seedu.address.model.person.Person;
 
 /**
@@ -73,6 +74,10 @@ public class EditIsolatedEventCommand extends Command {
         IsolatedEvent editedIsolatedEvent = createEditedIsolatedEvent(personToEdit, originalEvent, editEventDescriptor);
 
         editedIsolatedEvent.checkDateTime();
+
+        IsolatedEventList.listConflictedEventWithRecurring(editedIsolatedEvent, personToEdit.getRecurringEventList());
+
+        model.setIsolatedEvent(personToEdit, originalEvent, editedIsolatedEvent);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, editedIsolatedEvent)
                 + " from " + originalEvent + " for " + personToEdit.getName());

--- a/src/main/java/seedu/address/logic/commands/EditRecurringEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditRecurringEventCommand.java
@@ -90,6 +90,8 @@ public class EditRecurringEventCommand extends Command {
 
         editedRecurringEvent.checkPeriod();
 
+        RecurringEventList.listConflictedEventWithIsolated(editedRecurringEvent, personToEdit.getIsolatedEventList());
+
         model.setRecurringEvent(personToEdit, originalEvent, editedRecurringEvent);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, editedRecurringEvent)

--- a/src/main/java/seedu/address/model/event/RecurringEvent.java
+++ b/src/main/java/seedu/address/model/event/RecurringEvent.java
@@ -165,4 +165,33 @@ public class RecurringEvent extends Event implements Comparable<RecurringEvent> 
         return getEventName() + " on " + this.dayOfWeek.name() + " from " + startTime.toString() + " to "
                 + endTime.toString();
     }
+
+
+    /**
+     * To check if the day of the week falls between 2 dates
+     * @param startPeriod represents the starting date
+     * @param endPeriod represents the ending date
+     * @param dayOfWeek is the day of the week
+     * @return count which indicates how many the number of in which the day of week falls after the start period
+     *      and -1 if it does not fall between the 2 dates
+     */
+    public long numberOfDaysBetween(LocalDateTime startPeriod, LocalDateTime endPeriod, DayOfWeek dayOfWeek) {
+        long daysBetween = startPeriod.until(endPeriod, ChronoUnit.DAYS);
+        DayOfWeek startPeriodDay = startPeriod.getDayOfWeek();
+
+        DayOfWeek eventDay = startPeriodDay;
+        long count = 0;
+
+        for (int i = 0; i < daysBetween; i++) {
+            if (dayOfWeek.equals(eventDay)) {
+                break;
+            }
+            eventDay = eventDay.plus(1);
+            count++;
+        }
+        if (eventDay.equals(dayOfWeek)) {
+            return count;
+        }
+        return -1;
+    }
 }

--- a/src/main/java/seedu/address/model/event/RecurringEvent.java
+++ b/src/main/java/seedu/address/model/event/RecurringEvent.java
@@ -32,7 +32,6 @@ public class RecurringEvent extends Event implements Comparable<RecurringEvent> 
      */
     public RecurringEvent(String eventName, DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
         super(eventName);
-
         this.dayOfWeek = dayOfWeek;
         this.startTime = startTime;
         this.endTime = endTime;
@@ -159,7 +158,6 @@ public class RecurringEvent extends Event implements Comparable<RecurringEvent> 
         if (this.startTime.isAfter(this.endTime) || this.startTime.equals(this.endTime)) {
             throw new CommandException(RecurringEvent.MESSAGE_CONSTRAINTS_PERIOD);
         }
-
     }
 
     @Override

--- a/src/main/java/seedu/address/model/event/RecurringEventList.java
+++ b/src/main/java/seedu/address/model/event/RecurringEventList.java
@@ -1,12 +1,16 @@
 package seedu.address.model.event;
 
+import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.TreeSet;
 
+import seedu.address.model.event.exceptions.EventConflictException;
 import seedu.address.model.event.exceptions.EventNotFoundException;
+import seedu.address.model.person.Person;
 
 /**
  * Represents the list of {@code RecurringEvent} that each {@code Person} has.
@@ -32,6 +36,22 @@ public class RecurringEventList {
      */
     public void insert(RecurringEvent newEvent) {
         this.recurringEvents.add(newEvent);
+    }
+
+    public RecurringEvent checkClashingRecurringEvent(RecurringEvent recurringEvent) {
+        Iterator<RecurringEvent> it = recurringEvents.iterator();
+        RecurringEvent currEvent;
+
+        int count = 0;
+        while (it.hasNext()) {
+            currEvent = it.next();
+
+            if (recurringEvent.compareTo(currEvent) == 0) {
+                return currEvent;
+            }
+            count++;
+        }
+        return null;
     }
 
     /**
@@ -93,6 +113,7 @@ public class RecurringEventList {
     public Set<RecurringEvent> getSet() {
         return new TreeSet<>(this.recurringEvents);
     }
+
     /**
      * Prints out a list of all event that occur within the given time period
      * @param startPeriod stand for the starting date of the time period

--- a/src/main/java/seedu/address/model/event/RecurringEventList.java
+++ b/src/main/java/seedu/address/model/event/RecurringEventList.java
@@ -14,10 +14,6 @@ import seedu.address.model.event.exceptions.EventNotFoundException;
 public class RecurringEventList {
     private final TreeSet<RecurringEvent> recurringEvents = new TreeSet<>();
 
-    public void insert(RecurringEvent newEvent) {
-        this.recurringEvents.add(newEvent);
-    }
-
     public TreeSet<RecurringEvent> getRecurringEvents() {
         return recurringEvents;
     }
@@ -28,6 +24,32 @@ public class RecurringEventList {
      */
     public int getSize() {
         return recurringEvents.size();
+    }
+
+    /**
+     * Insert the recurring event object into the recurring event list
+     * @param newEvent to be inserted
+     */
+    public void insert(RecurringEvent newEvent) {
+        this.recurringEvents.add(newEvent);
+    }
+
+    /**
+     * Check if a recurring event exist within the recurring event list
+     * @param event to be checked if exist
+     * @return true if there exist a same event and false if the event does exist
+     * in the event list
+     */
+    public boolean contain(RecurringEvent event) {
+        return recurringEvents.contains(event);
+    }
+
+    /**
+     * Delete the recurring event from the recurring event list.
+     * @param event to be deleted.
+     */
+    public void deleteRecurringEvent(RecurringEvent event) {
+        recurringEvents.remove(event);
     }
 
     /**
@@ -49,20 +71,19 @@ public class RecurringEventList {
         return recurringEvent;
     }
 
-    @Override
-    public String toString() {
-        StringBuilder output = new StringBuilder("Recurring Events\n");
-        int count = 1;
-        for (RecurringEvent re : recurringEvents) {
-            output.append(count).append(". ").append(re.toString()).append("\n");
-            count++;
+    /**
+     * Edit recurring event parameters in the recurring event list
+     * @param originalEvent to be edited
+     * @param editedRecurringEvent to be edited to
+     */
+    public void edit(RecurringEvent originalEvent, RecurringEvent editedRecurringEvent) {
+        if (!recurringEvents.contains(originalEvent)) {
+            throw new EventNotFoundException();
         }
-        return output.toString();
+        recurringEvents.remove(originalEvent);
+        recurringEvents.add(editedRecurringEvent);
     }
 
-    public boolean contain(RecurringEvent event) {
-        return recurringEvents.contains(event);
-    }
     public void addAll(Set<RecurringEvent> recurringEvents) {
         this.recurringEvents.addAll(recurringEvents);
     }
@@ -88,20 +109,14 @@ public class RecurringEventList {
         return output.toString();
     }
 
-    public void deleteRecurringEvent(RecurringEvent event) {
-        recurringEvents.remove(event);
-    }
-
-    /**
-     * Edit recurring event parameters in the recurring event list
-     * @param originalEvent to be edited
-     * @param editedRecurringEvent to be edited to
-     */
-    public void edit(RecurringEvent originalEvent, RecurringEvent editedRecurringEvent) {
-        if (!recurringEvents.contains(originalEvent)) {
-            throw new EventNotFoundException();
+    @Override
+    public String toString() {
+        StringBuilder output = new StringBuilder("Recurring Events\n");
+        int count = 1;
+        for (RecurringEvent re : recurringEvents) {
+            output.append(count).append(". ").append(re.toString()).append("\n");
+            count++;
         }
-        recurringEvents.remove(originalEvent);
-        recurringEvents.add(editedRecurringEvent);
+        return output.toString();
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddRecurringEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddRecurringEventCommandTest.java
@@ -27,6 +27,7 @@ public class AddRecurringEventCommandTest {
 
     @Test
     public void execute_success() throws CommandException {
+
         Person editedPerson = new PersonBuilder().build();
         model.addPerson(editedPerson);
 
@@ -36,17 +37,10 @@ public class AddRecurringEventCommandTest {
         AddRecurringEventCommand command = new AddRecurringEventCommand(Index.fromOneBased(1),
                 recurringEvent);
 
-        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        expectedModel.addRecurringEvent(editedPerson, recurringEvent);
-
         String expectedMessage = String.format(AddRecurringEventCommand.MESSAGE_SUCCESS, recurringEvent) + " to "
                 + editedPerson.getName();
 
         assertEquals(expectedMessage, command.execute(model).getFeedbackToUser());
-
-        String expectedList = editedPerson.getRecurringEventList().toString();
-
-        assertEquals("Recurring Events\n1. biking on MONDAY from 12:00 to 14:00\n", expectedList);
 
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditIsolatedEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditIsolatedEventCommandTest.java
@@ -2,6 +2,9 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.commands.EditIsolatedEventCommand.MESSAGE_SUCCESS;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.SampleDateTimeUtil.FOUR_O_CLOCK_VALID;
+import static seedu.address.testutil.SampleDateTimeUtil.SIX_O_CLOCK_VALID;
 import static seedu.address.testutil.SampleDateTimeUtil.THREE_O_CLOCK_VALID;
 import static seedu.address.testutil.SampleDateTimeUtil.TWO_O_CLOCK_VALID;
 import static seedu.address.testutil.SampleEventUtil.SKIING_ISOLATED_EVENT;
@@ -17,6 +20,8 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.event.RecurringEvent;
+import seedu.address.model.event.exceptions.EventConflictException;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditEventDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -39,5 +44,24 @@ public class EditIsolatedEventCommandTest {
                 + " from " + SKIING_ISOLATED_EVENT + " for " + editedPerson.getName();
 
         assertEquals(expectedMessage, command.execute(model).getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_conflictRecurringEvent() throws CommandException {
+        Person editedPerson = new PersonBuilder().build();
+        model.addPerson(editedPerson);
+        model.addIsolatedEvent(editedPerson, SKIING_ISOLATED_EVENT);
+
+        model.addRecurringEvent(editedPerson, new RecurringEvent("Cycling", FOUR_O_CLOCK_VALID.getDayOfWeek(),
+                THREE_O_CLOCK_VALID.toLocalTime(), SIX_O_CLOCK_VALID.toLocalTime()));
+
+        EditEventDescriptor editEventDescriptor = new EditEventDescriptorBuilder("Sleep", TWO_O_CLOCK_VALID,
+                FOUR_O_CLOCK_VALID).build();
+
+        EditIsolatedEventCommand command = new EditIsolatedEventCommand(INDEX_FIRST_PERSON,
+                INDEX_FIRST_EVENT, editEventDescriptor);
+
+        assertThrows(EventConflictException.class, () ->command.execute(model));
+
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditRecurringEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditRecurringEventCommandTest.java
@@ -1,9 +1,11 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.SampleDateTimeUtil.THREE_O_CLOCK_VALID;
 import static seedu.address.testutil.SampleDateTimeUtil.TWO_O_CLOCK_VALID;
 import static seedu.address.testutil.SampleEventUtil.BIKING_RECURRING_EVENT;
+import static seedu.address.testutil.SampleEventUtil.GYM_ISOLATED_EVENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -17,6 +19,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.event.RecurringEvent;
+import seedu.address.model.event.exceptions.EventConflictException;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditEventDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -46,6 +49,26 @@ public class EditRecurringEventCommandTest {
                 + "Original Event: " + BIKING_RECURRING_EVENT + " for " + editedPerson.getName();
 
         assertEquals(expectedMessage, editCommand.execute(model).getFeedbackToUser());
+
+    }
+
+    @Test
+    public void execute_conflictIsolatedEvent() throws CommandException {
+
+        Person editedPerson = new PersonBuilder().build();
+
+        model.addPerson(editedPerson);
+        model.addRecurringEvent(editedPerson, BIKING_RECURRING_EVENT);
+        model.addIsolatedEvent(editedPerson, GYM_ISOLATED_EVENT);
+
+        EditRecurringEventCommand.EditEventDescriptor editEventDescriptor =
+                new EditEventDescriptorBuilder("Jogging", DayOfWeek.SATURDAY,
+                        TWO_O_CLOCK_VALID.toLocalTime(), THREE_O_CLOCK_VALID.toLocalTime()).recurringbuild();
+
+        EditRecurringEventCommand editCommand = new EditRecurringEventCommand(INDEX_FIRST_PERSON, INDEX_FIRST_EVENT,
+                editEventDescriptor);
+
+        assertThrows(EventConflictException.class, () ->editCommand.execute(model));
 
     }
 


### PR DESCRIPTION
Fix bug for issue #54 

- event_create_recur does not print an error whenever there is a clash or duplicate in recurring events
- event_create, event_create_recur, ie_edit and re_edit has an issue where the list of both recurring event and isolated events are not being cross check