### PR TITLE
fix bug for edit isolated event command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -18,6 +18,8 @@ public class Messages {
     public static final String MESSAGE_EVENT_CLASH = "You already have an event at this time period:\n%1$s";
     public static final String MESSAGE_EVENT_INVALID_DATE = "Invalid date! The date of event cannot be before the"
                                                                 + " current time!";
+    public static final String MESSAGE_INVALID_EVENT_INDEX = "The event index provided is invalid";
+
     public static final String MESSAGE_EVENT_START_AFTER_END = "The end time should not be earlier than the start time";
 
     public static final String MESSAGE_INVALID_GROUP_DISPLAYED_INDEX = "The group index provided is invalid";

--- a/src/main/java/seedu/address/logic/commands/EditIsolatedEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditIsolatedEventCommand.java
@@ -70,6 +70,11 @@ public class EditIsolatedEventCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(personIndex.getZeroBased());
+
+        if (eventIndex.getZeroBased() >= personToEdit.getIsolatedEventList().getSize()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_EVENT_INDEX);
+        }
+
         IsolatedEvent originalEvent = personToEdit.getIsolatedEventList().getIsolatedEvent(eventIndex.getZeroBased());
         IsolatedEvent editedIsolatedEvent = createEditedIsolatedEvent(personToEdit, originalEvent, editEventDescriptor);
 
@@ -81,7 +86,6 @@ public class EditIsolatedEventCommand extends Command {
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, editedIsolatedEvent)
                 + " from " + originalEvent + " for " + personToEdit.getName());
-
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditIsolatedEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditIsolatedEventCommandTest.java
@@ -11,6 +11,7 @@ import static seedu.address.testutil.SampleEventUtil.SKIING_ISOLATED_EVENT;
 import static seedu.address.testutil.SampleEventUtil.SLEEPING_ISOLATED_EVENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_EVENT;
 
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +48,7 @@ public class EditIsolatedEventCommandTest {
     }
 
     @Test
-    public void execute_conflictRecurringEvent() throws CommandException {
+    public void execute_conflictRecurringEvent() {
         Person editedPerson = new PersonBuilder().build();
         model.addPerson(editedPerson);
         model.addIsolatedEvent(editedPerson, SKIING_ISOLATED_EVENT);
@@ -62,6 +63,20 @@ public class EditIsolatedEventCommandTest {
                 INDEX_FIRST_EVENT, editEventDescriptor);
 
         assertThrows(EventConflictException.class, () ->command.execute(model));
+    }
+    @Test
+    public void execute_invalidEventIndex() throws CommandException {
+        Person editedPerson = new PersonBuilder().build();
+        Model model = new ModelManager(new AddressBook(), new UserPrefs());
+        model.addPerson(editedPerson);
+        model.addIsolatedEvent(editedPerson, SKIING_ISOLATED_EVENT);
 
+        EditEventDescriptor editEventDescriptor = new EditEventDescriptorBuilder("Sleep", TWO_O_CLOCK_VALID,
+                FOUR_O_CLOCK_VALID).build();
+
+        EditIsolatedEventCommand command = new EditIsolatedEventCommand(INDEX_FIRST_PERSON,
+                INDEX_THIRD_EVENT, editEventDescriptor);
+
+        assertThrows(CommandException.class, () ->command.execute(model));
     }
 }


### PR DESCRIPTION
bug found: keying in an event index that is larger than the size of the isolated event list will not throw any error. 

solution: throw command exception and notify user that the event index they keyed is invalid. 