### PR TITLE
fix bug: able to edit isolated event to clashing isolated event timing

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditIsolatedEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditIsolatedEventCommand.java
@@ -74,9 +74,8 @@ public class EditIsolatedEventCommand extends Command {
         IsolatedEvent editedIsolatedEvent = createEditedIsolatedEvent(personToEdit, originalEvent, editEventDescriptor);
 
         editedIsolatedEvent.checkDateTime();
-
+        personToEdit.getIsolatedEventList().listConflictedEventWithIsolated(editedIsolatedEvent);
         IsolatedEventList.listConflictedEventWithRecurring(editedIsolatedEvent, personToEdit.getRecurringEventList());
-
         model.setIsolatedEvent(personToEdit, originalEvent, editedIsolatedEvent);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, editedIsolatedEvent)

--- a/src/main/java/seedu/address/model/event/IsolatedEventList.java
+++ b/src/main/java/seedu/address/model/event/IsolatedEventList.java
@@ -1,10 +1,7 @@
 package seedu.address.model.event;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 import seedu.address.model.event.exceptions.EventConflictException;
 import seedu.address.model.event.exceptions.EventNotFoundException;
@@ -99,6 +96,29 @@ public class IsolatedEventList {
         isolatedEvents.remove(originalEvent);
         isolatedEvents.add(editedEvent);
     }
+
+    /**
+     * This function cross-check with the recurring event list to check for any conflicts
+     * @param isolatedEvent is the event to be added
+     * @throws EventConflictException if there is a conflicted event
+     */
+    public void listConflictedEventWithIsolated(IsolatedEvent isolatedEvent) throws EventConflictException {
+
+        LocalDateTime startPeriod = isolatedEvent.getStartDate();
+        LocalDateTime endPeriod = isolatedEvent.getEndDate();
+
+        int index = 1;
+
+        for (IsolatedEvent ie : this.isolatedEvents) {
+            LocalDateTime currStart = ie.getStartDate();
+            LocalDateTime currEnd = ie.getEndDate();
+            if (startPeriod.isAfter(currStart) || startPeriod.isBefore(currEnd)) {
+                throw new EventConflictException("Isolated Event:\n" + index + ". " + ie);
+            }
+            index++;
+        }
+    }
+
 
     /**
      * This function cross-check with the recurring event list to check for any conflicts


### PR DESCRIPTION
bug found: able to edit isolated event's timing such that it will clash with other isolated event's start/end time

solution: throw eventconflict exception 