### PR TITLE
Isolated event related fixes 

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -242,6 +242,8 @@ Format: `event_create INDEX ie/EVENT_NAME f/START_DATE t/END_DATE`
 * Creates an event with the specified name `EVENT_NAME` using the flag `ie/` which stands for Isolated event
 * The flags `f/` represent the word __from__ and `t/` represents the word __to__
 * `EVENT_NAME`, `START_DATE` and `END_DATE` cannot be left empty
+* If there are duplicate attributes (i.e. `event_create INDEX ie/test ie/test2 f/START_DATE t/END_DATE`), WGT will take the 
+info following the latest attribute (in the example case, WGT will take event name to be test 2). 
 
 * The format of both `START_DATE` and `END_DATE` would be in `dd/MM/yyyy HH:mm`
 * `START_DATE` has to be before the `END_DATE`

--- a/src/main/java/seedu/address/logic/parser/AddIsolatedEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddIsolatedEventCommandParser.java
@@ -47,6 +47,7 @@ public class AddIsolatedEventCommandParser implements Parser<AddIsolatedEventCom
         String eventName = ParserUtil.parseEventName(argMultimap.getValue(PREFIX_ISOEVENT).get());
         LocalDateTime startDate = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_STARTDATETIME).get());
         LocalDateTime endDate = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_ENDDATETIME).get());
+        ParserUtil.checkValidDateTime(startDate);
 
         IsolatedEvent eventToAdd = new IsolatedEvent(eventName, startDate, endDate);
         return new AddIsolatedEventCommand(index, eventToAdd);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -160,8 +160,16 @@ public class ParserUtil {
         if (dueDate.getMinute() != 0) {
             throw new ParseException(Event.MESSAGE_EVENT_NOT_HOURLY);
         }
-
         return dueDate;
+    }
+
+    public static void checkValidDateTime(LocalDateTime date) throws ParseException {
+        requireNonNull(date);
+        LocalDateTime now = LocalDateTime.now();
+
+        if (date.isBefore(now)) {
+            throw new ParseException(Messages.MESSAGE_EVENT_INVALID_DATE);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -163,6 +163,11 @@ public class ParserUtil {
         return dueDate;
     }
 
+    /**
+     * Check if the start date of the event if before the current date time.
+     * @param date in which the event starts
+     * @throws ParseException to be thrown if it is before the current date time.
+     */
     public static void checkValidDateTime(LocalDateTime date) throws ParseException {
         requireNonNull(date);
         LocalDateTime now = LocalDateTime.now();

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -69,7 +69,7 @@ public class AddressBookParserTest {
     public void parseCommand_isolatedEvent() throws Exception {
         AddIsolatedEventCommand command = (AddIsolatedEventCommand) parser.parseCommand(
                 AddIsolatedEventCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " "
-                        + "ie/biking" + " " + "f/09/03/2023 14:00" + " " + "t/09/03/2023 15:00");
+                        + "ie/biking" + " " + "f/09/03/2025 14:00" + " " + "t/09/03/2025 15:00");
         assertTrue(command.COMMAND_WORD == "event_create");
     }
 


### PR DESCRIPTION
bug found: able to add events that starts before the current date time. 
solution: throw parse exception now if users try to add events that starts before the current date time. 

ug update: informed users what will happen if they key in duplicate attributes. 